### PR TITLE
Fix issues

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "165fc6d22394c1168ff76ab5d951245971ef07e5",
-        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-06-05-a"
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,29 +5,29 @@ import PackageDescription
 import CompilerPluginSupport
 
 let package = Package(
-    name: "MacroLibrary",
+    name: "CustomCodingKeys",
     platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
-            name: "MacroLibrary",
-            targets: ["MacroLibrary"]
+            name: "CustomCodingKeys",
+            targets: ["CustomCodingKeys"]
         ),
         .executable(
-            name: "MacroLibraryClient",
-            targets: ["MacroLibraryClient"]
+            name: "CustomCodingKeysClient",
+            targets: ["CustomCodingKeysClient"]
         ),
     ],
     dependencies: [
-        // Depend on the latest Swift 5.9 prerelease of SwiftSyntax
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-04-25-b"),
+        // Depend on the Swift 5.9 release of SwiftSyntax
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         // Macro implementation that performs the source transformation of a macro.
         .macro(
-            name: "MacroLibraryMacros",
+            name: "CustomCodingKeysMacros",
             dependencies: [
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
@@ -35,16 +35,16 @@ let package = Package(
         ),
 
         // Library that exposes a macro as part of its API, which is used in client programs.
-        .target(name: "MacroLibrary", dependencies: ["MacroLibraryMacros"]),
+        .target(name: "CustomCodingKeys", dependencies: ["CustomCodingKeysMacros"]),
 
         // A client of the library, which is able to use the macro in its own code.
-        .executableTarget(name: "MacroLibraryClient", dependencies: ["MacroLibrary"]),
+        .executableTarget(name: "CustomCodingKeysClient", dependencies: ["CustomCodingKeys"]),
 
         // A test target used to develop the macro implementation.
         .testTarget(
-            name: "MacroLibraryTests",
+            name: "CustomCodingKeysTests",
             dependencies: [
-                "MacroLibraryMacros",
+                "CustomCodingKeysMacros",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
             ]
         ),

--- a/Sources/CustomCodingKeys/CustomCodingKeys.swift
+++ b/Sources/CustomCodingKeys/CustomCodingKeys.swift
@@ -1,4 +1,4 @@
-/// A macro annotation for creating a `CodingKeysMacro`.
+/// A macro annotation for creating a `CustomCodingKeysMacro`.
 /// This macro provides a shorthand way to generate a `CodingKeys` enumeration for a structure.
 /// The macro uses a dictionary where each key-value pair represents a key path to a property and
 /// its respective string representation.
@@ -6,9 +6,9 @@
 /// - Parameter _: A dictionary with `PartialKeyPath<T>` as key and `String` as value.
 /// The dictionary represents the mapping of properties to their respective string representation.
 /// The default value of this parameter is an empty dictionary.
-/// - Note: This macro requires the external macro provided by "MacroLibraryMacros".
+/// - Note: This macro requires the external macro provided by "CustomCodingKeysMacros".
 @attached(member, names: arbitrary)
-public macro CodingKeysMacro<T>(_ : [PartialKeyPath<T>: String] = [:]) = #externalMacro(
-    module: "MacroLibraryMacros",
-    type: "CodingKeysMacro"
+public macro customCodingKeys<T>(_ : [PartialKeyPath<T>: String] = [:]) = #externalMacro(
+    module: "CustomCodingKeysMacros",
+    type: "CustomCodingKeysMacro"
 )

--- a/Sources/CustomCodingKeys/CustomCodingKeys.swift
+++ b/Sources/CustomCodingKeys/CustomCodingKeys.swift
@@ -8,7 +8,7 @@
 /// The default value of this parameter is an empty dictionary.
 /// - Note: This macro requires the external macro provided by "CustomCodingKeysMacros".
 @attached(member, names: arbitrary)
-public macro customCodingKeys<T>(_ : [PartialKeyPath<T>: String] = [:]) = #externalMacro(
+public macro customCodingKeys(_ : [String: String] = [:]) = #externalMacro(
     module: "CustomCodingKeysMacros",
     type: "CustomCodingKeysMacro"
 )

--- a/Sources/CustomCodingKeysClient/main.swift
+++ b/Sources/CustomCodingKeysClient/main.swift
@@ -1,9 +1,9 @@
-import MacroLibrary
+import CustomCodingKeys
 
-@CodingKeysMacro<Address>([
-    \.buildingNumber: "building_number"
+@customCodingKeys([
+    \Address.buildingNumber: "building_number"
 ])
-struct Address: Codable {
+public struct Address: Codable {
     var buildingNumber: String?
     let city: String?
     let cityPart: String?
@@ -13,4 +13,3 @@ struct Address: Codable {
     let street: String?
     let zipCode: String?
 }
-

--- a/Sources/CustomCodingKeysClient/main.swift
+++ b/Sources/CustomCodingKeysClient/main.swift
@@ -1,7 +1,7 @@
 import CustomCodingKeys
 
 @customCodingKeys([
-    \Address.buildingNumber: "building_number"
+    "buildingNumber": "building_number"
 ])
 public struct Address: Codable {
     var buildingNumber: String?

--- a/Sources/CustomCodingKeysMacros/CustomCodingKeysMacro.swift
+++ b/Sources/CustomCodingKeysMacros/CustomCodingKeysMacro.swift
@@ -1,10 +1,9 @@
-import SwiftCompilerPlugin
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 /// A struct that defines a macro for automatically generating CodingKeys
-public struct CodingKeysMacro: MemberMacro {
+public struct CustomCodingKeysMacro: MemberMacro {
     
     /// Defines the types of errors that can occur in CodingKeysMacro
     private enum CodingKeysError: Error {
@@ -29,12 +28,12 @@ public struct CodingKeysMacro: MemberMacro {
             throw CodingKeysError.invalidDeclarationSyntax
         }
         
-        let attributeSyntax = declaration.attributes?.first?.as(AttributeSyntax.self)
-        let tupleSyntax = attributeSyntax?.argument?.as(TupleExprElementListSyntax.self)
+        let attributeSyntax = declaration.attributes.first?.as(AttributeSyntax.self)
+        let tupleSyntax = attributeSyntax?.arguments?.as(LabeledExprListSyntax.self)
         let content = tupleSyntax?.first?.expression.as(DictionaryExprSyntax.self)
         let dictionaryList = content?.content.as(DictionaryElementListSyntax.self)
-        let valueExpression = dictionaryList?.compactMap({$0.valueExpression.as(StringLiteralExprSyntax.self)})
-        let keyPathExpression = dictionaryList?.compactMap({$0.keyExpression.as(KeyPathExprSyntax.self)})
+        let valueExpression = dictionaryList?.compactMap({$0.value.as(StringLiteralExprSyntax.self)})
+        let keyPathExpression = dictionaryList?.compactMap({$0.key.as(KeyPathExprSyntax.self)})
         
         guard let keyPathSyntax = keyPathExpression?.compactMap({ $0.components }),
               let stringSegmentSyntax = valueExpression?.compactMap({$0.segments.first?.as(StringSegmentSyntax.self)})
@@ -101,14 +100,4 @@ public struct CodingKeysMacro: MemberMacro {
             """
         ]
     }
-}
-
-/// A struct that defines a compiler plugin.
-/// The plugin provides macros.
-@main
-struct MacroLibraryPlugin: CompilerPlugin {
-    /// An array of Macro types provided by the plugin.
-    let providingMacros: [Macro.Type] = [
-        CodingKeysMacro.self
-    ]
 }

--- a/Sources/CustomCodingKeysMacros/CustomCodingKeysPlugin.swift
+++ b/Sources/CustomCodingKeysMacros/CustomCodingKeysPlugin.swift
@@ -1,0 +1,9 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct CustomCodingKeysPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        CustomCodingKeysMacro.self
+    ]
+}


### PR DESCRIPTION
- Rename sources to enable custom library naming. 
- Fix breaking `SwiftMacros` library changes.
- Fix tests. 
- Fix `Circular reference resolving attached macro` error.